### PR TITLE
📦 Bump pypi:werkzeug:3.0.0 from 3.0.0 to 3.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ SQLAlchemy==2.0.21
 tomlkit==0.11.8
 typing_extensions==4.8.0
 urllib3==1.26.16
-Werkzeug==3.0.0
+Werkzeug==3.0.6
 wrapt==1.15.0


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-34069 | High  | The debugger in affected versions of Werine under certain circumstances. |
| CVE-2024-49767 | High  | Applications using `werkzeug.formparser.MultiPartParser` corresponding to a version of Werkzeug prior to 3.0.6 to parse `multipart/form-data` requests are vulnerable to a resource exhaustion (denial of service) attack. |
| CVE-2023-46136 | High  | A resource consumption flaw was found in python-werkzeug. If a specially crafted file is uploaded by a remote attacker, it may cause a denial of service. |
| CVE-2024-49766 | Unknown  | On Python versions earlier than 3.11 on Windows |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
