### PR TITLE
📦 Bump pypi:werkzeug:3.0.0 from 3.0.0 to 3.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ SQLAlchemy==2.0.21
 tomlkit==0.11.8
 typing_extensions==4.8.0
 urllib3==1.26.16
-Werkzeug==3.0.0
+Werkzeug==3.0.6
 wrapt==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astroid==2.15.4
 beautifulsoup4==4.12.2
 blinker==1.6.2
 bs4==0.0.1
-certifi==2022.9.24
+certifi==2024.07.04
 charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-MySQLdb==1.0.1
 Flask-SQLAlchemy==3.1.1
 greenlet==3.0.0
 gunicorn==20.1.0
-idna==3.4
+idna==3.7
 isort==5.12.0
 itsdangerous==2.1.2
 Jinja2==3.1.2


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-34069 | High  | The debugger in affected versions of Werkzeug can allow an attacker to execute code on a developer's machine under certain circumstances. |
| CVE-2024-49767 | High  | Applications using `werkzeug.formparser.MultiPartParser` corresponding to a version of Werkzeug prior to 3.0.6 to parse `multipart/form-data` requests are vulnerable to a resource exhaustion (denial of service) attack. |
| CVE-2023-46136 | High  | A resource consumption flaw was found in python-werkzeug. If a specially crafted file is uploaded by a remote attacker, it may cause a denial of service. |
| CVE-2024-49766 | Unknown  | On Python versions earlier than 3.11 on Windows, `os.path.isabs()` does not catch UNC paths like `//server/share`. Werkzeug's `safe_join()` relies on this check, and so can produce a path that is not safe, potentially allowing unintended access to data. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
