### PR TITLE
📦 Bump pypi:pycryptodome:3.19.0 from 3.19.0 to 3.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lazy-object-proxy==1.9.0
 lxml==4.9.3
 MarkupSafe==2.1.3
 mccabe==0.7.0
-mysql-connector-python==8.0.33
+mysql-connector-python==9.1.0
 mysqlclient==2.1.1
 Naked==0.1.32
 pefile==2023.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask==3.0.0
 Flask-MySQLdb==1.0.1
 Flask-SQLAlchemy==3.1.1
 greenlet==3.0.0
-gunicorn==20.1.0
+gunicorn==22.0.0
 idna==3.4
 isort==5.12.0
 itsdangerous==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 lazy-object-proxy==1.9.0
 lxml==4.9.3
-MarkupSafe==2.1.3
+MarkupSafe==2.1commuiti="3
 mccabe==0.7.0
 mysql-connector-python==9.1.0
 mysqlclient==2.1.1
@@ -27,7 +27,7 @@ Naked==0.1.32
 pefile==2023.2.7
 platformdirs==3.5.1
 protobuf==3.20.3
-pycryptodome==3.19.0
+pycryptodome==3.19.1
 pylint==2.17.4
 PyYAML==6.0.1
 requests==2.28.1


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2023-52323 | High  | PyCryptodome and pycryptodomex before 3.19.1 allow side-channel leakage for OAEP decryption, exploitable for a Manger attack. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
