### PR TITLE
📦 Bump pypi:gunicorn:20.1.0 from 20.1.0 to 22.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask==3.0.0
 Flask-MySQLdb==1.0.1
 Flask-SQLAlchemy==3.1.1
 greenlet==3.0.0
-gunicorn==20.1.0
+gunicorn==22.0.0
 idna==3.4
 isort==5.12.0
 itsdangerous==2.1.2


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-1135 | High  | Gunicorn fails to properly validate Transfer-Encoding headers, leading to<br>HTTP Request Smuggling (HRS) vulnerabilities. By crafting requests with<br>conflicting Transfer-Encoding headers, attackers can bypass security<br>restrictions and access restricted endpoints. This issue is due to<br>Gunicorn's handling of Transfer-Encoding headers, where it incorrectly<br>processes requests with multiple, conflicting Transfer-Encoding headers,<br>treating them as chunked regardless of the final encoding specified. This<br>vulnerability has been shown to allow access to endpoints restricted by<br>gunicorn. This issue has been addressed in version 22.0.0. To be affected<br>users must have a network path which does not filter out invalid requests.<br>These users are advised to block access to restricted endpoints via a<br>firewall or other mechanism if they are unable to update. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
