### PR TITLE
📦 Bump pypi:pycryptodome:3.19.0 from 3.19.0 to 3.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Naked==0.1.32
 pefile==2023.2.7
 platformdirs==3.5.1
 protobuf==3.20.3
-pycryptodome==3.19.0
+pycryptodome==3.19.1
 pylint==2.17.4
 PyYAML==6.0.1
 requests==2.28.1


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2023-52323 | High  | PyCryptodome and pycryptodomex before 3.19.1 allow side-channel leakage for OAEP<br>decryption, exploitable for a Manger attack. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
