### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lazy-object-proxy==1.9.0
 lxml==4.9.3
 MarkupSafe==2.1.3
 mccabe==0.7.0
-mysql-connector-python==8.0.33
+mysql-connector-python==9.1.0
 mysqlclient==2.1.1
 Naked==0.1.32
 pefile==2023.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask==3.0.0
 Flask-MySQLdb==1.0.1
 Flask-SQLAlchemy==3.1.1
 greenlet==3.0.0
-gunicorn==20.1.0
+gunicorn==22.0.0
 idna==3.4
 isort==5.12.0
 itsdangerous==2.1.2


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| pypi:mysql-connector-python:8.0.33 | CVE-2024-21272 | High  | Vulnerability in the MySQL Connectors product of Oracle MySQL<br>(component: Connector/Python). Supported versions that are<br>affected are 9.0.0 and prior. Difficult to exploit<br>vulnerability allows low privileged attacker with network<br>access via multiple protocols to compromise MySQL Connectors.<br>Successful attacks of this vulnerability can result in<br>takeover of MySQL Connectors. CVSS 3.1 Base Score 7.5<br>(Confidentiality, Integrity and Availability impacts). CVSS<br>Vector: (CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H). |
| pypi:gunicorn:20.1.0 | CVE-2024-1135 | High  | Gunicorn fails to properly validate Transfer-Encoding<br>headers, leading to HTTP Request Smuggling (HRS)<br>vulnerabilities. By crafting requests with conflicting<br>Transfer-Encoding headers, attackers can bypass security<br>restrictions and access restricted endpoints. This issue is<br>due to Gunicorn's handling of Transfer-Encoding headers,<br>where it incorrectly processes requests with multiple,<br>conflicting Transfer-Encoding headers, treating them as<br>chunked regardless of the final encoding specified. This<br>vulnerability has been shown to allow access to endpoints<br>restricted by gunicorn. This issue has been addressed in<br>version 22.0.0. To be affected users must have a network path<br>which does not filter out invalid requests. These users are<br>advised to block access to restricted endpoints via a<br>firewall or other mechanism if they are unable to update. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
