### PR TITLE
📦 Bump pypi:mysql-connector-python:8.0.33 from 8.0.33 to 9.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lazy-object-proxy==1.9.0
 lxml==4.9.3
 MarkupSafe==2.1.3
 mccabe==0.7.0
-mysql-connector-python==8.0.33
+mysql-connector-python==9.1.0
 mysqlclient==2.1.1
 Naked==0.1.32
 pefile==2023.2.7


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-21272 | High  | Vulnerability in the MySQL Connectors product of Oracle MySQL (component:<br>Connector/Python). Supported versions that are affected are 9.0.0 and prior.<br>Difficult to exploit vulnerability allows low privileged attacker with network<br>access via multiple protocols to compromise MySQL Connectors. Successful attacks<br>of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.1 Base<br>Score 7.5 (Confidentiality, Integrity and Availability impacts). CVSS Vector:<br>(CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H). |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
