### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.commitizen]
 version_type = "semver"
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Naked==0.1.32
 pefile==2023.2.7
 platformdirs==3.5.1
 protobuf==3.20.3
-pycryptodome==3.19.0
+pycryptodome==3.19.1
 pylint==2.17.4
 PyYAML==6.0.1
 requests==2.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ SQLAlchemy==2.0.21
 tomlkit==0.11.8
 typing_extensions==4.8.0
 urllib3==1.26.16
-Werkzeug==3.0.0
+Werkzeug==3.0.6
 wrapt==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ soupsieve==2.4.1
 SQLAlchemy==2.0.21
 tomlkit==0.11.8
 typing_extensions==4.8.0
-urllib3==1.26.16
+urllib3==2.0.6
 Werkzeug==3.0.6
 wrapt==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Naked==0.1.32
 pefile==2023.2.7
 platformdirs==3.5.1
 protobuf==3.20.3
-pycryptodome==3.19.1
+pycryptodome==3.19.0
 pylint==2.17.4
 PyYAML==6.0.1
 requests==2.28.1


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| pypi:pycryptodome:3.19.0 | CVE-2023-52323 | High  | PyCryptodome and pycryptodomex before 3.19.1 allow<br>side-channel leakage for OAEP decryption, exploitable for a<br>Manger attack. |
| pypi:werkzeug:3.0.0 | CVE-2024-49766 | Medium  | On Python < 3.11 on Windows, `os.path.isabs()` does not catch<br>UNC paths like `//server/share`. Werkzeug's `safe_join()`<br>relies on this check, and so can produce a path that is not<br>safe, potentially allowing unintended access to data.<br>Applications using Python >= 3.11, or not using Windows, are<br>not vulnerable. |
| pypi:werkzeug:3.0.0 | CVE-2024-49767 | Medium  | Applications using Werkzeug to parse `multipart/form-data`<br>requests are vulnerable to resource exhaustion. A specially<br>crafted form body can bypass the<br>`Request.max_form_memory_size` setting. The<br>`Request.max_content_length` setting, as well as resource<br>limits provided by deployment software and platforms, are<br>also available to limit the resources used during a request.<br>This vulnerability does not affect those settings. All three<br>types of limits should be considered and set appropriately<br>when deploying an application. |
| pypi:werkzeug:3.0.0 | CVE-2023-46136 | Medium  | Werkzeug multipart data parser needs to find a boundary that<br>may be between consecutive chunks. That's why parsing is<br>based on looking for newline characters. Unfortunately, code<br>looking for partial boundary in the buffer is written<br>inefficiently, so if we upload a file that starts with CR or<br>LF and then is followed by megabytes of data without these<br>characters: all of these bytes are appended chunk by chunk<br>into internal bytearray and lookup for boundary is performed<br>on growing buffer. This allows an attacker to cause a denial<br>of service by sending crafted multipart data to an endpoint<br>that will parse it. The amount of CPU time required can block<br>worker processes from handling legitimate requests. The<br>amount of RAM required can trigger an out of memory kill of<br>the process. If many concurrent requests are sent<br>continuously, this can exhaust or kill all available workers. |
| pypi:werkzeug:3.0.0 | CVE-2024-34069 | High  | The debugger in affected versions of Werkzeug can allow an<br>attacker to execute code on a developer's machine under some<br>circumstances. This requires the attacker to get the<br>developer to interact with a domain and subdomain they<br>control, and enter the debugger PIN, but if they are<br>successful it allows access to the debugger even if it is<br>only running on localhost. This also requires the attacker to<br>guess a URL in the developer's application that will trigger<br>the debugger. |
| pypi:urllib3:1.26.16 | CVE-2023-43804 | High  | urllib3 doesn't treat the `Cookie` HTTP header special or<br>provide any helpers for managing cookies over HTTP, that is<br>the responsibility of the user. However, it is possible for a<br>user to specify a `Cookie` header and unknowingly leak<br>information via HTTP redirects to a different origin if that<br>user doesn't disable redirects explicitly. Users **must**<br>handle redirects themselves instead of relying on urllib3's<br>automatic redirects to achieve safe processing of the<br>`Cookie` header, thus we decided to strip the header by<br>default in order to further protect users who aren't using<br>the correct approach. ## Affected usages We believe the<br>number of usages affected by this advisory is low. It<br>requires all of the following to be true to be exploited: *<br>Using an affected version of urllib3 (patched in v1.26.17 and<br>v2.0.6) * Using the `Cookie` header on requests, which is<br>mostly typical for impersonating a browser. * Not disabling<br>HTTP redirects * Either not using HTTPS or for the origin<br>server to redirect to a malicious origin. ## Remediation *<br>Upgrading to at least urllib3 v1.26.17 or v2.0.6 * Disabling<br>HTTP redirects using `redirects=False` when sending requests.<br>* Not using the `Cookie` header. |
| pypi:urllib3:1.26.16 | CVE-2023-45803 | Medium  | urllib3 previously wouldn't remove the HTTP request body when<br>an HTTP redirect response using status 303 "See Other" after<br>the request had its method changed from one that could accept<br>a request body (like `POST`) to `GET` as is required by HTTP<br>RFCs. Although the behavior of removing the request body is<br>not specified in the section for redirects, it can be<br>inferred by piecing together information from different<br>sections and we have observed the behavior in other major<br>HTTP client implementations like curl and web browsers. From<br>[RFC 9110 Section<br>9.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-get):<br>> A client SHOULD NOT generate content in a GET request<br>unless it is made directly to an origin server that has<br>previously indicated, in or out of band, that such a request<br>has a purpose and will be adequately supported. ## Affected<br>usages Because the vulnerability requires a previously<br>trusted service to become compromised in order to have an<br>impact on confidentiality we believe the exploitability of<br>this vulnerability is low. Additionally, many users aren't<br>putting sensitive data in HTTP request bodies, if this is the<br>case then this vulnerability isn't exploitable. Both of the<br>following conditions must be true to be affected by this<br>vulnerability: * If you're using urllib3 and submitting<br>sensitive information in the HTTP request body (such as form<br>data or JSON) * The origin service is compromised and starts<br>redirecting using 303 to a malicious peer or the<br>redirected-to service becomes compromised. ## Remediation You<br>can remediate this vulnerability with any of the following<br>steps: * Upgrade to a patched version of urllib3 (v1.26.18 or<br>v2.0.7) * Disable redirects for services that you aren't<br>expecting to respond with redirects with `redirects=False`. *<br>Disable automatic redirects with `redirects=False` and handle<br>303 redirects manually by stripping the HTTP request body. |
| pypi:urllib3:1.26.16 | CVE-2024-37891 | Medium  | When using urllib3's proxy support with `ProxyManager`, the<br>`Proxy-Authorization` header is only sent to the configured<br>proxy, as expected. However, when sending HTTP requests<br>*without* using urllib3's proxy support, it's possible to<br>accidentally configure the `Proxy-Authorization` header even<br>though it won't have any effect as the request is not using a<br>forwarding proxy or a tunneling proxy. In those cases,<br>urllib3 doesn't treat the `Proxy-Authorization` HTTP header<br>as one carrying authentication material and thus doesn't<br>strip the header on cross-origin redirects. Because this is a<br>highly unlikely scenario, we believe the severity of this<br>vulnerability is low for almost all users. Out of an<br>abundance of caution urllib3 will automatically strip the<br>`Proxy-Authorization` header during cross-origin redirects to<br>avoid the small chance that users are doing this on accident.<br>Users should use urllib3's proxy support or disable automatic<br>redirects to achieve safe processing of the<br>`Proxy-Authorization` header, but we still decided to strip<br>the header by default in order to further protect users who<br>aren't using the correct approach. ## Affected usages We<br>believe the number of usages affected by this advisory is<br>low. It requires all of the following to be true to be<br>exploited: * Setting the `Proxy-Authorization` header without<br>using urllib3's built-in proxy support. * Not disabling HTTP<br>redirects. * Either not using an HTTPS origin server or for<br>the proxy or target origin to redirect to a malicious origin.<br>## Remediation * Using the `Proxy-Authorization` header with<br>urllib3's `ProxyManager`. * Disabling HTTP redirects using<br>`redirects=False` when sending requests. * Not using the<br>`Proxy-Authorization` header. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
